### PR TITLE
Include requester ID when requesting share token.

### DIFF
--- a/server/auth/service.py
+++ b/server/auth/service.py
@@ -51,6 +51,7 @@ def is_token_expired(token) -> bool:
 
 
 def request_share_token(
+    requester_id: str,
     own_token: str,
     shared_resource: str,
     duration: int,
@@ -68,8 +69,8 @@ def request_share_token(
         base_url + "/auth/request_share_token",
         headers={"Authorization": own_token},
         json={
-            "requester": "1",
-            "file_path": "test.txt",
+            "requester": requester_id,
+            "file_path": shared_resource,
             "duration": duration,
             "permissions": requested_permissions,
         },

--- a/server/auth/views.py
+++ b/server/auth/views.py
@@ -111,6 +111,7 @@ def generate_sharing_link():
 
     permissions_needed = ["read: files", "read: disk_storage"]
     share_token = service.request_share_token(
+        g.user.get("id"),
         g.auth_token,
         file_path,
         duration,

--- a/server/auth/views.py
+++ b/server/auth/views.py
@@ -111,7 +111,7 @@ def generate_sharing_link():
 
     permissions_needed = ["read: files", "read: disk_storage"]
     share_token = service.request_share_token(
-        g.user.get("id"),
+        str(g.user.get("id")),
         g.auth_token,
         file_path,
         duration,

--- a/server/tests/test_sharing_link.py
+++ b/server/tests/test_sharing_link.py
@@ -78,7 +78,7 @@ def test_sharing_link(
 
     assert auth_repo_request.headers["Authorization"] == auth_token
     assert call.kwargs["json"] == {
-        "requester": "1",
+        "requester": "2",
         "file_path": "test.txt",
         "duration": str(60 * 60 * 60),
         "permissions": ["read: files", "read: disk_storage"],


### PR DESCRIPTION
Also provide the proper resource name, rather than hardcoded "test.txt"